### PR TITLE
Fix a small bug about Access out of Bounds

### DIFF
--- a/src/IrisDatasetTest.cpp
+++ b/src/IrisDatasetTest.cpp
@@ -63,7 +63,7 @@ bool load_data(int *samples,
     double *p = &((*input)[0]) + i * input_size;
     double *c = &((*iris_class)[0]) + i * number_classes;
     for (int k = 0; k < number_classes; k++) {
-      c[i] = 0.0;
+      c[k] = 0.0;
     }
 
     fgets(line, 1024, in);


### PR DESCRIPTION
This is a small bug while coding, but it will cause strange exception while running by VS2022, which may have more strict check about access out of bounds.